### PR TITLE
Feature/unit tests for editor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,9 +46,9 @@ jobs:
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
       # No tests yet
-      # - name: Run tests
-      #   run: |
-      #     cargo test
+      - name: Run tests
+        run: |
+          cargo test
   fmt:
     name: Rust formatting
     runs-on: ubuntu-latest

--- a/src/app/editor/mod.rs
+++ b/src/app/editor/mod.rs
@@ -127,10 +127,12 @@ impl Input {
         Ok(AppReturn::Continue)
     }
 
+    /// Remove last character from the current line.
     pub fn pop(&mut self) -> Option<char> {
         self.lines[self.current_row as usize].text.get_mut().pop()
     }
 
+    /// Moves the cursor one line up.
     pub fn up_row(&mut self) -> Result<AppReturn> {
         if self.current_row > 0 {
             match self.lines[self.current_row as usize]
@@ -157,6 +159,7 @@ impl Input {
         Ok(AppReturn::Continue)
     }
 
+    /// Moves the cursor one line down.
     pub fn down_row(&mut self) -> Result<AppReturn> {
         if self.lines.is_empty() {
             return Ok(AppReturn::Continue);
@@ -170,6 +173,7 @@ impl Input {
         Ok(AppReturn::Continue)
     }
 
+    /// Moves the cursor to the next character.
     pub fn next_char(&mut self) -> Result<AppReturn> {
         if self.lines.is_empty()
             || self.cursor_column
@@ -188,6 +192,7 @@ impl Input {
         Ok(AppReturn::Continue)
     }
 
+    /// Moves the cursor to the previous character.
     pub fn previous_char(&mut self) -> Result<AppReturn> {
         if (self.cursor_column == 0) && (self.current_row > 0) {
             self.current_row -= 1;
@@ -198,6 +203,13 @@ impl Input {
         Ok(AppReturn::Continue)
     }
 
+    #[allow(dead_code)]
+    /// Returns the number of UTF8 characters in the line where the cursor is located.
+    /// This function is only required, if the editor needs to support non-ascii characters
+    /// which have more then 1 byte. <br>
+    /// Example: <br>
+    /// "abcd" has 4 characters and 4 bytes <br>
+    /// "äbcd" has 4 characters but 5 bytes (first character requires 2 bytes)
     fn number_chars_in_current_line(&self) -> usize {
         self.lines[self.cursor_row as usize]
             .text
@@ -399,19 +411,17 @@ impl Editor {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
     use crate::app::editor::{Input, Line};
+    use std::io::Cursor;
 
     #[test]
     fn can_delete_non_ascii_characters() {
         let mut input: Input = Input {
-            lines: vec![
-                Line {
-                    text: Cursor::new(String::from("äää")),
-                }
-            ],
+            lines: vec![Line {
+                text: Cursor::new(String::from("äää")),
+            }],
             cursor_row: 0,
-            cursor_column: 3
+            cursor_column: 3,
         };
 
         input.backspace().expect("Expect that can delete character");
@@ -426,17 +436,18 @@ mod tests {
     #[test]
     fn next_character_in_one_line() {
         let mut input: Input = Input {
-            lines: vec![
-                Line {
-                    text: Cursor::new(String::from("aaa")),
-                },
-            ],
+            lines: vec![Line {
+                text: Cursor::new(String::from("aaa")),
+            }],
             cursor_row: 0,
-            cursor_column: 0
+            cursor_column: 0,
         };
 
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_column, 1, "When moving once, cursor should be after first character");
+        assert_eq!(
+            input.cursor_column, 1,
+            "When moving once, cursor should be after first character"
+        );
 
         input.next_char().expect("Could move to next character");
         assert_eq!(input.cursor_column, 2);
@@ -445,32 +456,44 @@ mod tests {
         assert_eq!(input.cursor_column, 3);
 
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_column, 3, "When line is over and no next line exists, cursor should stop");
-        assert_eq!(input.cursor_row, 0, "When line is over and no next line exists, cursor should stop");
+        assert_eq!(
+            input.cursor_column, 3,
+            "When line is over and no next line exists, cursor should stop"
+        );
+        assert_eq!(
+            input.cursor_row, 0,
+            "When line is over and no next line exists, cursor should stop"
+        );
     }
 
     #[test]
     fn previous_character_in_one_line() {
         let mut input: Input = Input {
-            lines: vec![
-                Line {
-                    text: Cursor::new(String::from("aaa")),
-                },
-            ],
+            lines: vec![Line {
+                text: Cursor::new(String::from("aaa")),
+            }],
             cursor_row: 0,
-            cursor_column: 3
+            cursor_column: 3,
         };
 
-        input.previous_char().expect("Could move to previous character");
+        input
+            .previous_char()
+            .expect("Could move to previous character");
         assert_eq!(input.cursor_column, 2);
 
-        input.previous_char().expect("Could move to previous character");
+        input
+            .previous_char()
+            .expect("Could move to previous character");
         assert_eq!(input.cursor_column, 1);
 
-        input.previous_char().expect("Could move to previous character");
+        input
+            .previous_char()
+            .expect("Could move to previous character");
         assert_eq!(input.cursor_column, 0);
 
-        input.previous_char().expect("Could move to previous character");
+        input
+            .previous_char()
+            .expect("Could move to previous character");
         assert_eq!(input.cursor_column, 0);
     }
 
@@ -481,13 +504,12 @@ mod tests {
                 Line {
                     text: Cursor::new(String::from("aa")),
                 },
-
                 Line {
                     text: Cursor::new(String::from("bb")),
                 },
             ],
             cursor_row: 0,
-            cursor_column: 0
+            cursor_column: 0,
         };
 
         input.next_char().expect("Could move to next character");
@@ -495,12 +517,21 @@ mod tests {
 
         // we expect to jump to the next line here
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_row, 1, "Cursor should have jumped to next line");
-        assert_eq!(input.cursor_column, 0, "Cursor should be at beginning of the line");
+        assert_eq!(
+            input.cursor_row, 1,
+            "Cursor should have jumped to next line"
+        );
+        assert_eq!(
+            input.cursor_column, 0,
+            "Cursor should be at beginning of the line"
+        );
 
         input.next_char().expect("Could move to next character");
         assert_eq!(input.cursor_row, 1);
-        assert_eq!(input.cursor_column, 1, "Cursor should be at the end of second line");
+        assert_eq!(
+            input.cursor_column, 1,
+            "Cursor should be at the end of second line"
+        );
 
         input.next_char().expect("Could move to next character");
         assert_eq!(input.cursor_row, 1);
@@ -508,7 +539,10 @@ mod tests {
 
         input.next_char().expect("Could move to next character");
         assert_eq!(input.cursor_row, 1);
-        assert_eq!(input.cursor_column, 2, "When there is no next line, cursor should stay unchanged");
+        assert_eq!(
+            input.cursor_column, 2,
+            "When there is no next line, cursor should stay unchanged"
+        );
     }
 
     #[test]
@@ -518,42 +552,43 @@ mod tests {
                 Line {
                     text: Cursor::new(String::from("aa")),
                 },
-
                 Line {
                     text: Cursor::new(String::from("bb")),
                 },
             ],
             cursor_row: 1,
-            cursor_column: 0
+            cursor_column: 0,
         };
 
         input.previous_char().expect("Could move to next character");
-        assert_eq!(input.cursor_row, 0, "Cursor should have jumped to previous line");
-        assert_eq!(input.cursor_column, 1, "Cursor should be at end of the previous line");
+        assert_eq!(
+            input.cursor_row, 0,
+            "Cursor should have jumped to previous line"
+        );
+        assert_eq!(
+            input.cursor_column, 1,
+            "Cursor should be at end of the previous line"
+        );
     }
 
     #[test]
     fn non_ascii_character_count() {
         let input: Input = Input {
-            lines: vec![
-                Line {
-                    text: Cursor::new(String::from("äää")),
-                }
-            ],
+            lines: vec![Line {
+                text: Cursor::new(String::from("äää")),
+            }],
             cursor_row: 0,
-            cursor_column: 0
+            cursor_column: 0,
         };
 
         assert_eq!(input.number_chars_in_current_line(), 3);
 
         let input2: Input = Input {
-            lines: vec![
-                Line {
-                    text: Cursor::new(String::from("äääb")),
-                }
-            ],
+            lines: vec![Line {
+                text: Cursor::new(String::from("äääb")),
+            }],
             cursor_row: 0,
-            cursor_column: 0
+            cursor_column: 0,
         };
         assert_eq!(input2.number_chars_in_current_line(), 4);
     }
@@ -599,7 +634,11 @@ mod tests {
         input.append_char('a').expect("Could append a character");
         assert_eq!(input.cursor_row, 0);
         assert_eq!(input.cursor_column, 2);
-        assert_eq!(input.number_chars_in_current_line(), 7, "{}", format!("Line is: {}", input.lines[input.cursor_row as usize].text.get_ref()));
+        assert_eq!(
+            input.number_chars_in_current_line(),
+            7,
+            "Line: {}", input.lines[input.cursor_row as usize].text.get_ref()
+        );
 
         // Input: "äab    \n"
         //        "a|"       <- cursor |
@@ -634,12 +673,15 @@ mod tests {
                 },
             ],
             cursor_row: 0,
-            cursor_column: 2
+            cursor_column: 2,
         };
 
         input.up_row().expect("No exception should be thrown.");
         assert_eq!(input.cursor_row, 0, "At 0th line, up_row has no effect");
-        assert_eq!(input.cursor_column, 2, "When up_row has no effect, the location inside the line should stay unchanged");
+        assert_eq!(
+            input.cursor_column, 2,
+            "When up_row has no effect, the location inside the line should stay unchanged"
+        );
 
         input.down_row().expect("No exception should be thrown.");
         assert_eq!(input.cursor_row, 1);
@@ -663,8 +705,10 @@ mod tests {
 
         input.up_row().expect("No exception should be thrown.");
         assert_eq!(input.cursor_row, 3);
-        assert_eq!(input.cursor_column, 0, "When coming from an empty line, the cursor should be at 0th position.");
-
+        assert_eq!(
+            input.cursor_column, 0,
+            "When coming from an empty line, the cursor should be at 0th position."
+        );
 
         let mut input2: Input = Input::default();
         // this use case caused a bug
@@ -680,5 +724,4 @@ mod tests {
         assert_eq!(input2.lines[0].text.get_ref(), "a\n");
         assert_eq!(input2.lines[1].text.get_ref(), "b");
     }
-
 }

--- a/src/app/editor/mod.rs
+++ b/src/app/editor/mod.rs
@@ -211,7 +211,7 @@ impl Input {
     /// "abcd" has 4 characters and 4 bytes <br>
     /// "äbcd" has 4 characters but 5 bytes (first character requires 2 bytes)
     fn number_chars_in_current_line(&self) -> usize {
-        self.lines[self.cursor_row as usize]
+        self.lines[self.current_row as usize]
             .text
             .get_ref()
             .chars()
@@ -414,8 +414,8 @@ mod tests {
     use crate::app::editor::{Input, Line};
     use std::io::Cursor;
 
-    #[should_panic]
     #[test]
+    #[should_panic]
     fn can_delete_non_ascii_characters() {
         //
         // Due to missing support for non-ascii characters, this test panics.
@@ -425,16 +425,16 @@ mod tests {
             lines: vec![Line {
                 text: Cursor::new(String::from("äää")),
             }],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 3,
         };
 
         input.backspace().expect("Expect that can delete character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 2);
 
         input.backspace().expect("Expect that can delete character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 1);
     }
 
@@ -444,7 +444,7 @@ mod tests {
             lines: vec![Line {
                 text: Cursor::new(String::from("aaa")),
             }],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 0,
         };
 
@@ -466,7 +466,7 @@ mod tests {
             "When line is over and no next line exists, cursor should stop"
         );
         assert_eq!(
-            input.cursor_row, 0,
+            input.current_row, 0,
             "When line is over and no next line exists, cursor should stop"
         );
     }
@@ -477,7 +477,7 @@ mod tests {
             lines: vec![Line {
                 text: Cursor::new(String::from("aaa")),
             }],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 3,
         };
 
@@ -502,8 +502,8 @@ mod tests {
         assert_eq!(input.cursor_column, 0);
     }
 
-    #[ignore]
     #[test]
+    #[ignore]
     fn jump_to_next_line_on_next_character_at_the_end_of_line() {
         // This functionality is not implemented but could come in later releases.
         let mut input: Input = Input {
@@ -515,7 +515,7 @@ mod tests {
                     text: Cursor::new(String::from("bb")),
                 },
             ],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 0,
         };
 
@@ -525,7 +525,7 @@ mod tests {
         // we expect to jump to the next line here
         input.next_char().expect("Could move to next character");
         assert_eq!(
-            input.cursor_row, 1,
+            input.current_row, 1,
             "Cursor should have jumped to next line"
         );
         assert_eq!(
@@ -534,26 +534,26 @@ mod tests {
         );
 
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(
             input.cursor_column, 1,
             "Cursor should be at the end of second line"
         );
 
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(input.cursor_column, 2);
 
         input.next_char().expect("Could move to next character");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(
             input.cursor_column, 2,
             "When there is no next line, cursor should stay unchanged"
         );
     }
 
-    #[ignore]
     #[test]
+    #[ignore]
     fn jump_to_previous_line_on_previous_character_at_the_beginning_of_line() {
         // This functionality is not implemented but could come in later releases.
         let mut input: Input = Input {
@@ -565,13 +565,13 @@ mod tests {
                     text: Cursor::new(String::from("bb")),
                 },
             ],
-            cursor_row: 1,
+            current_row: 1,
             cursor_column: 0,
         };
 
         input.previous_char().expect("Could move to next character");
         assert_eq!(
-            input.cursor_row, 0,
+            input.current_row, 0,
             "Cursor should have jumped to previous line"
         );
         assert_eq!(
@@ -586,7 +586,7 @@ mod tests {
             lines: vec![Line {
                 text: Cursor::new(String::from("äää")),
             }],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 0,
         };
 
@@ -596,14 +596,14 @@ mod tests {
             lines: vec![Line {
                 text: Cursor::new(String::from("äääb")),
             }],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 0,
         };
         assert_eq!(input2.number_chars_in_current_line(), 4);
     }
 
-    #[should_panic]
     #[test]
+    #[should_panic]
     fn test_append_char() {
         //
         // Due to missing support for non-ascii characters, this test panics.
@@ -613,32 +613,32 @@ mod tests {
 
         // Input: ""
         input.append_char('ä').expect("Could append a character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 1);
         assert_eq!(input.number_chars_in_current_line(), 1);
 
         // Input: "ä"
         input.append_char('b').expect("Could append a character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 2);
         assert_eq!(input.number_chars_in_current_line(), 2);
 
         // Input: "äb"
         input.append_char('\t').expect("Could append a character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 6);
         assert_eq!(input.number_chars_in_current_line(), 6);
 
         // Input: "äb    "
         input.append_char('\n').expect("Could append a character");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(input.cursor_column, 0);
         assert_eq!(input.number_chars_in_current_line(), 0);
 
         // Input: "äb    \n"
         //        ""
         input.append_char('a').expect("Could append a character");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(input.cursor_column, 1);
         assert_eq!(input.number_chars_in_current_line(), 1);
 
@@ -646,13 +646,13 @@ mod tests {
         //        "a"
         input.up_row().expect("Can go up");
         input.append_char('a').expect("Could append a character");
-        assert_eq!(input.cursor_row, 0);
+        assert_eq!(input.current_row, 0);
         assert_eq!(input.cursor_column, 2);
         assert_eq!(
             input.number_chars_in_current_line(),
             7,
             "Line: {}",
-            input.lines[input.cursor_row as usize].text.get_ref()
+            input.lines[input.current_row as usize].text.get_ref()
         );
 
         // Input: "äab    \n"
@@ -662,7 +662,7 @@ mod tests {
         input.append_char('b').expect("Can type a character");
         // Input: "äab    \n"
         //        "b|a"  <- cursor |
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(input.cursor_column, 1);
         assert_eq!(input.lines[1].text.get_ref(), "ba");
     }
@@ -687,39 +687,39 @@ mod tests {
                     text: Cursor::new(String::from("dddd")),
                 },
             ],
-            cursor_row: 0,
+            current_row: 0,
             cursor_column: 2,
         };
 
         input.up_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 0, "At 0th line, up_row has no effect");
+        assert_eq!(input.current_row, 0, "At 0th line, up_row has no effect");
         assert_eq!(
             input.cursor_column, 2,
             "When up_row has no effect, the location inside the line should stay unchanged"
         );
 
         input.down_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 1);
+        assert_eq!(input.current_row, 1);
         assert_eq!(input.cursor_column, 2);
 
         input.down_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 2);
+        assert_eq!(input.current_row, 2);
         assert_eq!(input.cursor_column, 2);
 
         input.down_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 3);
+        assert_eq!(input.current_row, 3);
         assert_eq!(input.cursor_column, 0);
 
         input.down_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 4);
+        assert_eq!(input.current_row, 4);
         assert_eq!(input.cursor_column, 0);
 
         input.down_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 4, "At last line, down_row has no effect");
+        assert_eq!(input.current_row, 4, "At last line, down_row has no effect");
         assert_eq!(input.cursor_column, 0);
 
         input.up_row().expect("No exception should be thrown.");
-        assert_eq!(input.cursor_row, 3);
+        assert_eq!(input.current_row, 3);
         assert_eq!(
             input.cursor_column, 0,
             "When coming from an empty line, the cursor should be at 0th position."
@@ -731,10 +731,10 @@ mod tests {
         input2.append_char('\n').expect("Can append new line");
         input2.up_row().expect("Can go up");
         input2.down_row().expect("Can go down");
-        assert_eq!(input2.cursor_row, 1);
+        assert_eq!(input2.current_row, 1);
         assert_eq!(input2.cursor_column, 0);
         input2.append_char('b').expect("Can append char");
-        assert_eq!(input2.cursor_row, 1);
+        assert_eq!(input2.current_row, 1);
         assert_eq!(input2.cursor_column, 1);
         assert_eq!(input2.lines[0].text.get_ref(), "a\n");
         assert_eq!(input2.lines[1].text.get_ref(), "b");

--- a/src/app/editor/mod.rs
+++ b/src/app/editor/mod.rs
@@ -605,7 +605,7 @@ mod tests {
         //        "a|"       <- cursor |
         input.down_row().expect("Can go down");
         input.previous_char().expect("Can go left");
-        input.append_char('b');
+        input.append_char('b').expect("Can type a character");
         // Input: "äab    \n"
         //        "b|a"  <- cursor |
         assert_eq!(input.cursor_row, 1);

--- a/src/app/editor/mod.rs
+++ b/src/app/editor/mod.rs
@@ -414,8 +414,13 @@ mod tests {
     use crate::app::editor::{Input, Line};
     use std::io::Cursor;
 
+    #[should_panic]
     #[test]
     fn can_delete_non_ascii_characters() {
+        //
+        // Due to missing support for non-ascii characters, this test panics.
+        // #[should_panic] should be removed as soon as non-ascii chars are supported.
+        //
         let mut input: Input = Input {
             lines: vec![Line {
                 text: Cursor::new(String::from("äää")),
@@ -497,8 +502,10 @@ mod tests {
         assert_eq!(input.cursor_column, 0);
     }
 
+    #[ignore]
     #[test]
     fn jump_to_next_line_on_next_character_at_the_end_of_line() {
+        // This functionality is not implemented but could come in later releases.
         let mut input: Input = Input {
             lines: vec![
                 Line {
@@ -545,8 +552,10 @@ mod tests {
         );
     }
 
+    #[ignore]
     #[test]
     fn jump_to_previous_line_on_previous_character_at_the_beginning_of_line() {
+        // This functionality is not implemented but could come in later releases.
         let mut input: Input = Input {
             lines: vec![
                 Line {
@@ -593,8 +602,13 @@ mod tests {
         assert_eq!(input2.number_chars_in_current_line(), 4);
     }
 
+    #[should_panic]
     #[test]
     fn test_append_char() {
+        //
+        // Due to missing support for non-ascii characters, this test panics.
+        // #[should_panic] should be removed as soon as non-ascii chars are supported.
+        //
         let mut input: Input = Input::default();
 
         // Input: ""
@@ -637,7 +651,8 @@ mod tests {
         assert_eq!(
             input.number_chars_in_current_line(),
             7,
-            "Line: {}", input.lines[input.cursor_row as usize].text.get_ref()
+            "Line: {}",
+            input.lines[input.cursor_row as usize].text.get_ref()
         );
 
         // Input: "äab    \n"


### PR DESCRIPTION
Few unit tests for testing the functionality in the editor tab.
Right now, 4 tests out of (new) 8 are failing. 2 of them are related to handling of non-ascii characters. 2 are user-experience-related and are not that important (when in the beginning/end of the line, the cursor should jump to previous/next line when left/right buttons are pressed).

