### PR TITLE
Add support for `-f` command to run commands from files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +619,17 @@ checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1329,6 +1356,7 @@ name = "datafusion-tui"
 version = "0.1.0"
 dependencies = [
  "arrow-flight",
+ "assert_cmd",
  "async-trait",
  "clap",
  "color-eyre",
@@ -1342,9 +1370,11 @@ dependencies = [
  "lazy_static",
  "log",
  "object_store",
+ "predicates",
  "ratatui",
  "serde",
  "strum",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1476,6 +1506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1631,15 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2350,6 +2395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,6 +2745,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3419,6 +3500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3957,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.76",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ tui-logger = {version = "0.12", features = ["tracing-support"]}
 tui-textarea = "0.6.1"
 url = { version = "2.5.2", optional = true }
 
+[dev-dependencies]
+assert_cmd = "2.0.16"
+predicates = "3.1.2"
+tempfile = "3.2.0"
+
 [features]
 deltalake = ["dep:deltalake"]
 flightsql = ["dep:arrow-flight", "dep:tonic"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# datafusion-tui (dft)
+# dft
 
-DataFusion-tui provides an extensible terminal based data analysis tool that uses [DataFusion](https://github.com/apache/arrow-datafusion) as query execution engines. It has drawn inspiration and several features from `datafusion-cli`. In contrast to `datafusion-cli` a focus of `dft` is to provide an interface for leveraging DataFusions extensibility (for example connecting to `ObjectStore`s or querying custom `TableProvider`s).
+`dft` provides two interfaces to the [DataFusion](https://github.com/apache/arrow-datafusion) query execution engine:
+1. Text User Interface (TUI): An extensible terminal based data analysis tool that allows users to query and join data from disparate data sources.
+2. Command Line Interface (CLI): Scriptable engine for executing queries from files.
+
+`dft` is inspired by  [`datafusion-cli`], but has some differences:
+1. `dft` TUI focuses on more complete and interactive experience for users.
+2. `dft` contains many built in integrations such as Delta Lake, Iceberg, and MySQL that are not available in `datafusion-cli`.
+
+[`datafusion-cli`]: https://datafusion.apache.org/user-guide/cli/overview.html
+
+## `dft` TUI
 
 The objective of `dft` is to provide users with the experience of having their own local database that allows them to query and join data from disparate data sources all from the terminal.  
 
@@ -51,6 +61,20 @@ Some of the current and planned features are:
   - Iceberg (TODO)
   - Hudi (TODO)
 - Preloading DDL from `~/.datafusion/.datafusionrc` for local database available on startup
+- "Catalog File" support
+  - Save table definitions *and* data
+  - Save parquet metadata from remote object stores
+
+  
+## `dft` CLI
+
+The `dft` CLI is a scriptable engine for executing queries from files.  It is used in a similar manner to `datafusion-cli` but with the added benefit of being able to query from multiple data sources.
+
+For example you can run the contents of `query.sql` with 
+
+```shell
+$ dft -f query.sql
+```
 
 ## User Guide
 

--- a/src/app/execution.rs
+++ b/src/app/execution.rs
@@ -121,7 +121,8 @@ impl ExecutionContext {
         &self.session_ctx
     }
 
-    pub async fn execute_stream_sql(&mut self, query: &str) -> Result<()> {
+    /// Executes the specified query and prints the result to stdout
+    pub async fn execute_stream_sql(&self, query: &str) -> Result<()> {
         let df = self.session_ctx.sql(query).await.unwrap();
         let physical_plan = df.create_physical_plan().await.unwrap();
         // We use small batch size because web socket stream comes in small increments (each

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -358,7 +358,7 @@ pub async fn exec_from_file(ctx: &ExecutionContext, file: &Path) -> Result<()> {
         // if we found the end of a query, run it
         if line.ends_with(';') {
             // TODO: if the query errors, should we keep trying to execute
-            // the rest of the file? That is what datafusion-cli does
+            // the other queries in the file? That is what datafusion-cli does...
             ctx.execute_stream_sql(&query).await?;
             query.clear();
         } else {

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -61,9 +61,9 @@ pub fn initialize(args: &cli::DftCli) -> AppState {
     let data_dir = get_data_dir();
     let config_path = args.get_config();
     debug!("Config path: {:?}", config_path);
-    let config = if config_path.clone().is_some_and(|p| p.exists()) {
+    let config = if config_path.exists() {
         debug!("Config exists");
-        let maybe_config_contents = std::fs::read_to_string(config_path.unwrap());
+        let maybe_config_contents = std::fs::read_to_string(config_path);
         if let Ok(config_contents) = maybe_config_contents {
             let maybe_parsed_config: std::result::Result<AppConfig, toml::de::Error> =
                 toml::from_str(&config_contents);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,10 +22,18 @@ use clap::{Parser, Subcommand};
 use crate::app::config::get_data_dir;
 
 const LONG_ABOUT: &str = "
-Dft
+dft - DataFusion TUI
+
+CLI and terminal UI data analysis tool using Apache DataFusion as query
+execution engine.
+
+dft provides a rich terminal UI as well as a broad array of pre-integrated
+data sources, formats to make querying and analyzing data from
+various sources.
 
 Environment Variables
-RUST_LOG { trace | debug | info | error }: Standard across rust ecosystem for determining log level of application.  Default is info.
+
+RUST_LOG { trace | debug | info | error }: Standard rust logging level.  Default is info.
 ";
 
 #[derive(Clone, Debug, Parser)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -45,7 +45,8 @@ pub struct DftCli {
         help = "Execute commands from file(s), then exit",
         value_parser(parse_valid_file)
     )]
-    file: Vec<String>,
+    pub file: Vec<PathBuf>,
+
     #[clap(short, long, help = "Path to the configuration file")]
     pub config: Option<String>,
 }
@@ -66,10 +67,13 @@ impl DftCli {
     }
 }
 
-fn parse_valid_file(dir: &str) -> Result<String, String> {
-    if Path::new(dir).is_file() {
-        Ok(dir.to_string())
+fn parse_valid_file(file: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(file);
+    if !path.exists() {
+        Err(format!("File does not exist: '{file}'"))
+    } else if !path.is_file() {
+        Err(format!("Exists but is not a file: '{file}'"))
     } else {
-        Err(format!("Invalid file '{}'", dir))
+        Ok(path)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod telemetry;
 mod ui;
 
 use crate::app::state;
-use app::run_app;
+use app::{execute_files, run_app};
 use clap::Parser;
 use color_eyre::Result;
 
@@ -30,6 +30,13 @@ async fn main() -> Result<()> {
     telemetry::initialize_logs()?;
     let cli = cli::DftCli::parse();
     let state = state::initialize(&cli);
-    run_app(cli.clone(), state).await?;
+
+    // If executing commands from files, do so and then exit
+    if !cli.file.is_empty() {
+        execute_files(cli.file.clone(), &state).await?;
+    } else {
+        run_app(cli.clone(), state).await?;
+    }
+
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,236 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests for the CLI (e.g. run from files)
+
+use assert_cmd::Command;
+use predicates::str::ContainsPredicate;
+use std::path::PathBuf;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_help() {
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success();
+
+    assert.stdout(contains_str("dft"));
+}
+
+#[test]
+#[ignore]
+fn test_logging() {
+    // currently fails with
+    // Error: Device not configured (os error 6)
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .env("RUST_LOG", "info")
+        .assert()
+        .success();
+
+    assert.stdout(contains_str("INFO"));
+}
+
+#[test]
+fn test_command_in_file() {
+    let expected = r##"
++---------------------+
+| Int64(1) + Int64(1) |
++---------------------+
+| 2                   |
++---------------------+
+    "##;
+
+    let file = sql_in_file("SELECT 1 + 1");
+    assert_output_contains(vec![file], expected);
+
+    // same test but with a semicolon at the end
+    let file = sql_in_file("SELECT 1 + 1;");
+    assert_output_contains(vec![file], expected);
+}
+
+#[test]
+fn test_multiple_commands_in_file() {
+    let expected = r##"
++---------+
+| column1 |
++---------+
+| 42      |
++---------+
++------------------------+
+| foo.column1 + Int64(2) |
++------------------------+
+| 44                     |
++------------------------+
+    "##;
+
+    let sql = r#"
+-- The first line is a comment
+CREATE TABLE foo as values (42);
+-- lets ignore some whitespace
+
+    SELECT column1 FROM foo;
+
+-- Another comment
+SELECT column1 + 2 FROM foo
+    "#;
+
+    let file = sql_in_file(sql);
+    assert_output_contains(vec![file], expected);
+
+    // same test but with a semicolon at the end of second command
+    let file = sql_in_file(format!("{sql};"));
+    assert_output_contains(vec![file], expected);
+}
+
+#[test]
+fn test_multiple_commands_in_multiple_files() {
+    let expected = r##"
++---------------------+
+| Int64(1) + Int64(2) |
++---------------------+
+| 3                   |
++---------------------+
++----------+
+| Int64(1) |
++----------+
+| 1        |
++----------+
++----------+
+| Int64(2) |
++----------+
+| 2        |
++----------+
+    "##;
+
+    let file1 = sql_in_file("SELECT 1 + 2");
+    let file2 = sql_in_file("SELECT 1;\nselect 2;");
+    assert_output_contains(vec![file1, file2], expected);
+}
+
+#[test]
+fn test_non_existent_file() {
+    let file = sql_in_file("SELECT 1 + 1");
+    let p = PathBuf::from(file.path());
+    // dropping the file makes it non existent
+    drop(file);
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(&p)
+        .assert()
+        .failure();
+
+    let expected = format!("File does not exist: '{}'", p.to_string_lossy());
+    assert.code(2).stderr(contains_str(&expected));
+}
+
+#[test]
+fn test_one_existent_and_one_non_existent_file() {
+    let file1 = sql_in_file("SELECT 1 + 1");
+    let file2 = sql_in_file("SELECT 3 + 4");
+    let p1 = PathBuf::from(file1.path());
+    let p2 = PathBuf::from(file2.path());
+    // dropping the file makes it non existent
+    drop(file2);
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(p1)
+        .arg("-f")
+        .arg(&p2)
+        .assert()
+        .failure();
+
+    let expected_err = format!("File does not exist: '{}'", p2.to_string_lossy());
+    assert.code(2).stderr(contains_str(&expected_err));
+}
+
+#[test]
+fn test_sql_err_in_file() {
+    let file = sql_in_file("SELECT this is not valid SQL");
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(file.path())
+        .assert()
+        .failure();
+
+    let expected_err =
+        "Expected: [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: not";
+    assert.code(101).stderr(contains_str(expected_err));
+}
+
+#[test]
+fn test_sql_err_in_file_after_first() {
+    let file = sql_in_file(
+        r#"
+-- First line is valid SQL
+SELECT 1 + 1;
+-- Second line is not
+SELECT this is not valid SQL
+    "#,
+    );
+
+    let assert = Command::cargo_bin("dft")
+        .unwrap()
+        .arg("-f")
+        .arg(file.path())
+        .assert()
+        .failure();
+
+    let expected_err =
+        "Expected: [NOT] NULL or TRUE|FALSE or [NOT] DISTINCT FROM after IS, found: not";
+    assert.code(101).stderr(contains_str(expected_err));
+}
+
+/// Creates a temporary file with the given SQL content
+fn sql_in_file(sql: impl AsRef<str>) -> NamedTempFile {
+    let file = NamedTempFile::new().unwrap();
+    std::fs::write(file.path(), sql.as_ref()).unwrap();
+    file
+}
+
+/// Returns a predicate that expects the given string to be contained in the
+/// output
+///
+/// Whitespace is trimmed from the start and end of the string
+fn contains_str(s: &str) -> ContainsPredicate {
+    predicates::str::contains(s.trim())
+}
+
+/// Invokes `dft -f` with the given files and asserts that it exited
+/// successfully and the output contains the given string
+fn assert_output_contains(files: Vec<NamedTempFile>, expected_output: &str) {
+    let mut cmd = Command::cargo_bin("dft").unwrap();
+    for file in &files {
+        cmd.arg("-f").arg(file.path());
+    }
+
+    let assert = cmd.assert().success();
+
+    // Since temp files are deleted when they go out of scope ensure they are
+    // dropped only after the command is run
+    drop(files);
+
+    assert.stdout(contains_str(expected_output));
+}


### PR DESCRIPTION
This is my (very tardy) downpayment to help `dft`

It adds a simple "run commands from a file" mode via the `-f` argument and adds some basic tests

Here is an example:
```
andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion-tui$ cat ~/Downloads/q.sql
show all
andrewlamb@Andrews-MacBook-Pro-2:~/Software/datafusion-tui$ dft -f ~/Downloads/q.sql  | head
+-------------------------------------------------------------------------+---------------------------+
| name                                                                    | value                     |
+-------------------------------------------------------------------------+---------------------------+
| datafusion.catalog.create_default_catalog_and_schema                    | true                      |
| datafusion.catalog.default_catalog                                      | datafusion                |
| datafusion.catalog.default_schema                                       | public                    |
| datafusion.catalog.format                                               |                           |
| datafusion.catalog.has_header                                           | false                     |
| datafusion.catalog.information_schema                                   | false                     |
| datafusion.catalog.location                                             |                           |
```


Things I hope to do next:
1. Add support for `-c <sql string>`
2. Move the execution machinery into its own module (out of app) and start adding other integrations