### PR TITLE
Multiple statements working

### DIFF
--- a/src/app/execution.rs
+++ b/src/app/execution.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -126,24 +125,6 @@ impl ExecutionContext {
     pub fn session_ctx(&self) -> &SessionContext {
         &self.session_ctx
     }
-
-    // pub async fn run_statements(
-    //     &self,
-    //     statements: VecDeque<Statement>,
-    //     sender: UnboundedSender<AppEvent>,
-    // ) -> Result<()> {
-    //     let statement_count = statements.len();
-    //     for (i, statement) in statements.into_iter().enumerate() {
-    //         if i == statement_count - 1 {
-    //             self.execute_and_measure_statement(statement, ResultHandler::DisplayInTui)
-    //                 .await?;
-    //         } else {
-    //             self.execute_and_measure_statement(statement, ResultHandler::Discard)
-    //                 .await?;
-    //         }
-    //     }
-    //     Ok(())
-    // }
 
     pub async fn run_sqls(&self, sqls: Vec<&str>, sender: UnboundedSender<AppEvent>) -> Result<()> {
         let statement_count = sqls.len();

--- a/src/app/execution.rs
+++ b/src/app/execution.rs
@@ -127,12 +127,11 @@ impl ExecutionContext {
     }
 
     pub async fn run_sqls(&self, sqls: Vec<&str>, sender: UnboundedSender<AppEvent>) -> Result<()> {
-        let statement_count = sqls.len();
-        for (i, sql) in sqls.into_iter().enumerate() {
-            if sql.is_empty() {
-                info!("Query is empty, skipping");
-                continue;
-            }
+        // We need to filter out empty strings to correctly determine the last query for displaying
+        // results.
+        let non_empty_sqls: Vec<&str> = sqls.into_iter().filter(|s| !s.is_empty()).collect();
+        let statement_count = non_empty_sqls.len();
+        for (i, sql) in non_empty_sqls.into_iter().enumerate() {
             info!("Running query {}", i);
             let _sender = sender.clone();
             let mut query =

--- a/src/app/handlers/flightsql.rs
+++ b/src/app/handlers/flightsql.rs
@@ -70,9 +70,10 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
             info!("Run FS query");
             let sql = app.state.flightsql_tab.editor().lines().join("");
             info!("SQL: {}", sql);
-            let client = Arc::clone(&app.execution.flightsql_client);
+            let execution = Arc::clone(&app.execution);
             let _event_tx = app.app_event_tx.clone();
             tokio::spawn(async move {
+                let client = &execution.flightsql_client;
                 let mut query =
                     FlightSQLQuery::new(sql.clone(), None, None, None, Duration::default(), None);
                 let start = Instant::now();

--- a/src/app/handlers/mod.rs
+++ b/src/app/handlers/mod.rs
@@ -206,8 +206,9 @@ pub fn app_event_handler(app: &mut App, event: AppEvent) -> Result<()> {
             let url = app.state.config.flightsql.connection_url.clone();
             info!("Connection to FlightSQL host: {}", url);
             let url: &'static str = Box::leak(url.into_boxed_str());
-            let client = Arc::clone(&app.execution.flightsql_client);
+            let execution = Arc::clone(&app.execution);
             tokio::spawn(async move {
+                let client = &execution.flightsql_client;
                 let maybe_channel = Channel::from_static(url).connect().await;
                 info!("Created channel");
                 match maybe_channel {

--- a/src/app/handlers/sql.rs
+++ b/src/app/handlers/sql.rs
@@ -15,16 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Instant};
 
-use datafusion::{
-    arrow::array::RecordBatch,
-    physical_plan::execute_stream,
-    sql::{parser::DFParser, sqlparser::dialect::GenericDialect},
-};
+use datafusion::{arrow::array::RecordBatch, physical_plan::execute_stream};
 use log::{error, info};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio_stream::StreamExt;
@@ -74,76 +67,14 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
             info!("Run query");
             let sql = app.state.sql_tab.editor().lines().join("");
             info!("SQL: {}", sql);
-            // let mut query = Query::new(sql.clone(), None, None, None, Duration::default(), None);
-            // let ctx = app.execution.session_ctx.clone();
             let execution = Arc::clone(&app.execution);
             let _event_tx = app.app_event_tx.clone();
             // TODO: Maybe this should be on a separate runtime to prevent blocking main thread /
             // runtime
             // TODO: Extract this into function to be used in both normal and editable handler
             tokio::spawn(async move {
-                let dialect = GenericDialect {};
-                // let statements = DFParser::parse_sql_with_dialect(&sql, &dialect);
                 let sqls: Vec<&str> = sql.split(';').collect();
-                execution.run_sqls(sqls, _event_tx).await;
-                // match sqls {
-                //     Ok(statements) => {
-                //         execution.run_statements(statements, _event_tx).await;
-                //     }
-                //     Err(e) => error!("Error parsing SQL: {:?}", e),
-                // }
-
-                // let start = std::time::Instant::now();
-                // match ctx.sql(&sql).await {
-                //     Ok(df) => {
-                //         let plan = df.create_physical_plan().await;
-                //         match plan {
-                //             Ok(p) => {
-                //                 let task_ctx = ctx.task_ctx();
-                //                 let stream = execute_stream(Arc::clone(&p), task_ctx);
-                //                 let mut batches: Vec<RecordBatch> = Vec::new();
-                //                 match stream {
-                //                     Ok(mut s) => {
-                //                         while let Some(b) = s.next().await {
-                //                             match b {
-                //                                 Ok(b) => {
-                //                                     info!("Got batch with {} rows", b.num_rows());
-                //                                     batches.push(b)
-                //                                 }
-                //                                 Err(e) => {
-                //                                     error!("Error getting batch {:?}", e);
-                //                                 }
-                //                             }
-                //                         }
-                //
-                //                         let elapsed = start.elapsed();
-                //                         let stats = collect_plan_stats(p);
-                //                         info!("Got stats: {:?}", stats);
-                //                         let rows: usize =
-                //                             batches.iter().map(|b| b.num_rows()).sum();
-                //                         query.set_num_rows(Some(rows));
-                //                         query.set_execution_time(elapsed);
-                //                         query.set_results(Some(batches));
-                //                         query.set_execution_stats(stats);
-                //                     }
-                //                     Err(e) => {
-                //                         error!("Error getting RecordBatchStream: {:?}", e)
-                //                     }
-                //                 }
-                //             }
-                //             Err(e) => {
-                //                 error!("Error constructing physical plan: {:?}", e)
-                //             }
-                //         }
-                //     }
-                //     Err(e) => {
-                //         error!("Error creating dataframe: {:?}", e);
-                //         let elapsed = start.elapsed();
-                //         query.set_error(Some(e.to_string()));
-                //         query.set_execution_time(elapsed);
-                //     }
-                // }
-                // let _ = _event_tx.send(AppEvent::QueryResult(query));
+                let _ = execution.run_sqls(sqls, _event_tx).await;
             });
         }
         _ => {}


### PR DESCRIPTION
This lets you have multiple queries in the editor so you can do things like this.

<img width="1916" alt="image" src="https://github.com/user-attachments/assets/8b6f3443-0e5f-4b36-b6a1-f87dd3a172bc">

~Its still a bit messy~ (ive cleaned it up).  Ive had to play with how the execution will work. Initially tried running a  `Statement` but since in the editor we want to store the raw sql with each execution it was easier to just stick with that for now.

Playing with this, after the additions for the CLI features, definitely makes it clear well need to figure out the appropriate execution abstractions.