### PR TITLE
Extract `ExecutionContext` to its own module and cli code to `CliApp`

### DIFF
--- a/src/app/handlers/flightsql.rs
+++ b/src/app/handlers/flightsql.rs
@@ -73,7 +73,7 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
             let execution = Arc::clone(&app.execution);
             let _event_tx = app.app_event_tx.clone();
             tokio::spawn(async move {
-                let client = &execution.flightsql_client;
+                let client = execution.flightsql_client();
                 let mut query =
                     FlightSQLQuery::new(sql.clone(), None, None, None, Duration::default(), None);
                 let start = Instant::now();

--- a/src/app/handlers/mod.rs
+++ b/src/app/handlers/mod.rs
@@ -161,7 +161,7 @@ pub fn app_event_handler(app: &mut App, event: AppEvent) -> Result<()> {
         AppEvent::ExecuteDDL(ddl) => {
             let queries: Vec<String> = ddl.split(';').map(|s| s.to_string()).collect();
             queries.into_iter().for_each(|q| {
-                let ctx = app.execution.session_ctx.clone();
+                let ctx = app.execution.session_ctx().clone();
                 tokio::spawn(async move {
                     match ctx.sql(&q).await {
                         Ok(df) => {
@@ -208,7 +208,7 @@ pub fn app_event_handler(app: &mut App, event: AppEvent) -> Result<()> {
             let url: &'static str = Box::leak(url.into_boxed_str());
             let execution = Arc::clone(&app.execution);
             tokio::spawn(async move {
-                let client = &execution.flightsql_client;
+                let client = execution.flightsql_client();
                 let maybe_channel = Channel::from_static(url).connect().await;
                 info!("Created channel");
                 match maybe_channel {

--- a/src/app/handlers/sql.rs
+++ b/src/app/handlers/sql.rs
@@ -22,12 +22,9 @@ use log::{error, info};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio_stream::StreamExt;
 
-use crate::app::{
-    execution::collect_plan_stats, handlers::tab_navigation_handler, state::tabs::sql::Query,
-    AppEvent,
-};
-
 use super::App;
+use crate::app::{handlers::tab_navigation_handler, state::tabs::sql::Query, AppEvent};
+use crate::execution::collect_plan_stats;
 
 pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
     match key.code {
@@ -89,7 +86,7 @@ pub fn editable_handler(app: &mut App, key: KeyEvent) {
         (KeyCode::Esc, _) => app.state.sql_tab.exit_edit(),
         (KeyCode::Enter, KeyModifiers::CONTROL) => {
             let query = app.state.sql_tab.editor().lines().join("");
-            let ctx = app.execution.session_ctx.clone();
+            let ctx = app.execution.session_ctx().clone();
             let _event_tx = app.app_event_tx.clone();
             // TODO: Maybe this should be on a separate runtime to prevent blocking main thread /
             // runtime

--- a/src/app/state/tabs/flightsql.rs
+++ b/src/app/state/tabs/flightsql.rs
@@ -25,7 +25,7 @@ use ratatui::style::Style;
 use ratatui::widgets::TableState;
 use tui_textarea::TextArea;
 
-use crate::app::execution::ExecutionStats;
+use crate::execution::ExecutionStats;
 
 #[derive(Clone, Debug)]
 pub struct FlightSQLQuery {

--- a/src/app/state/tabs/history.rs
+++ b/src/app/state/tabs/history.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use ratatui::widgets::TableState;
 
-use crate::app::execution::ExecutionStats;
+use crate::execution::ExecutionStats;
 
 #[derive(Debug)]
 pub enum Context {

--- a/src/app/state/tabs/sql.rs
+++ b/src/app/state/tabs/sql.rs
@@ -25,7 +25,7 @@ use ratatui::style::Style;
 use ratatui::widgets::TableState;
 use tui_textarea::TextArea;
 
-use crate::app::execution::ExecutionStats;
+use crate::execution::ExecutionStats;
 
 #[derive(Clone, Debug)]
 pub struct Query {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
 pub mod cli;
+pub mod execution;
 pub mod telemetry;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 use color_eyre::Result;
-use dft::app::{execute_files_or_commands, run_app, state};
+use dft::app::{run_app, state, CliApp};
 use dft::cli;
 use dft::telemetry;
 
@@ -25,13 +25,17 @@ use dft::telemetry;
 async fn main() -> Result<()> {
     let cli = cli::DftCli::parse();
 
-    // If executing commands from files, do so and then exit
+    // CLI mode: executing commands from files or CLI arguments
     if !cli.files.is_empty() || !cli.commands.is_empty() {
         // use env_logger to setup logging for CLI
         env_logger::init();
         let state = state::initialize(cli.clone());
-        execute_files_or_commands(cli.files.clone(), cli.commands.clone(), &state).await?;
-    } else {
+        let app = CliApp::new(state);
+        app.execute_files_or_commands(cli.files.clone(), cli.commands.clone())
+            .await?;
+    }
+    // UI mode: running the TUI
+    else {
         // use alternate logging for TUI
         telemetry::initialize_logs()?;
         let state = state::initialize(cli.clone());


### PR DESCRIPTION
Part of https://github.com/datafusion-contrib/datafusion-tui/issues/132

This PR extracts the ExecutionContext into its own module, as a first step towards
adding additional features (e.g. other table formats)

Having it as its own module will allow us to test it more easily and keeps the boundaries of the software clearer.

Changes:
1. Move ExecutionContext to its own module
2. Make fields not `pub`
3. Encapsulate the CLI code into its own module
