### PR TITLE
Fix clippy warning about loop that never executes

### DIFF
--- a/src/app/handlers/flightsql.rs
+++ b/src/app/handlers/flightsql.rs
@@ -91,14 +91,12 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
                                                     Ok(batch) => {
                                                         info!("Batch rows: {}", batch.num_rows());
                                                         batches.push(batch);
-                                                        break;
                                                     }
                                                     Err(e) => {
                                                         error!("Error getting batch: {:?}", e);
                                                         let elapsed = start.elapsed();
                                                         query.set_error(Some(e.to_string()));
                                                         query.set_execution_time(elapsed);
-                                                        break;
                                                     }
                                                 }
                                             }

--- a/src/app/handlers/flightsql.rs
+++ b/src/app/handlers/flightsql.rs
@@ -86,7 +86,12 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
                                     match c.do_get(ticket.into_request()).await {
                                         Ok(mut stream) => {
                                             let mut batches: Vec<RecordBatch> = Vec::new();
-                                            while let Some(maybe_batch) = stream.next().await {
+                                            // temporarily only show the first batch to avoid
+                                            // buffering massive result sets. Eventually there should
+                                            // be some sort of paging logic
+                                            // see https://github.com/datafusion-contrib/datafusion-tui/pull/133#discussion_r1756680874
+                                            // while let Some(maybe_batch) = stream.next().await {
+                                            if let Some(maybe_batch) = stream.next().await {
                                                 match maybe_batch {
                                                     Ok(batch) => {
                                                         info!("Batch rows: {}", batch.num_rows());
@@ -100,7 +105,6 @@ pub fn normal_mode_handler(app: &mut App, key: KeyEvent) {
                                                     }
                                                 }
                                             }
-
                                             let elapsed = start.elapsed();
                                             let rows: usize =
                                                 batches.iter().map(|r| r.num_rows()).sum();


### PR DESCRIPTION
When the `flightsql` feature is enabled clippy is failing with this warning

```
error: this loop never actually loops
   --> src/app/handlers/flightsql.rs:89:45
    |
89  | / ...                   while let Some(maybe_batch) = stream.next().await {
90  | | ...                       match maybe_batch {
91  | | ...                           Ok(batch) => {
92  | | ...                               info!("Batch rows: {}", batch.num_rows());
...   |
103 | | ...                       }
104 | | ...                   }
    | |_______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
    = note: `#[deny(clippy::never_loop)]` on by default
```

This code fixes it